### PR TITLE
Suggestions for devfile compatibility with Che/CRW

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=827846
+  // for the documentation about the extensions.json format
+  "recommendations": [
+    "redhat.java"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "java",
+            "name": "Debug (Attach) - Remote",
+            "request": "attach",
+            "hostName": "localhost",
+            "port": 5005
+        }
+    ]
+}

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -11,11 +11,6 @@ metadata:
   language: "java"
   provider: Red Hat
   supportUrl: https://github.com/devfile-samples/devfile-support#support-information
-starterProjects:
-  - name: springbootproject
-    git:
-      remotes:
-        origin: "https://github.com/odo-devfiles/springboot-ex.git"
 components:
   - name: outerloop-build
     image:
@@ -30,11 +25,20 @@ components:
   - name: tools
     container:
       image: quay.io/eclipse/che-java11-maven:7.36.0
-      memoryLimit: 768Mi
-      mountSources: true
+      memoryLimit: 1Gi
+      cpuLimit: 500m
+      env:
+      - name: DEBUG_PORT
+        value: '5005'
       endpoints:
-      - name: '8080-tcp'
+      - name: 8080-tcp
+        exposure: public
+        protocol: http
         targetPort: 8080
+      - name: debug
+        exposure: none
+        protocol: tcp
+        targetPort: 5005
       volumeMounts:
         - name: m2
           path: /home/user/.m2


### PR DESCRIPTION
Some changes to the devfile to discuss and eventually apply to other devfiles:  

1. Set `$DEBUG_PORT`
2. Remove `starterProjects` as the devfile is in a repo and should not be used as a "stack"
3. Add a `.vscode/extensions.json` and `.vscode/launch.json` to configure Theia (Che IDE) and VS Code (local IDE)
4. Set `exposure: none` for the debug endpoint
5. Augment memory limit to 1G as less than that may be low for a Java projects 
6. Specify CPU limit

This issue comment has some general devfile suggestions https://github.com/devfile/api/issues/681#issuecomment-972594175 