### PR TITLE
use the fully qualified image url

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@
 #
 # docker run -i --rm -p 8081:8081 springboot/sample-demo
 ####
-FROM maven:3.8.1-openjdk-17-slim
+FROM docker.io/library/maven:3.8.1-openjdk-17-slim
 
 WORKDIR /build
 
@@ -20,7 +20,7 @@ RUN mvn dependency:go-offline
 COPY src src
 RUN mvn package -Dmaven.test.skip=true
 
-FROM openjdk:11-jdk
+FROM docker.io/library/openjdk:11-jdk
 COPY --from=0 /build/target/demo-0.0.1-SNAPSHOT.jar /app/target/demo-0.0.1-SNAPSHOT.jar
 
 EXPOSE 8081


### PR DESCRIPTION
You wouldn't want vendors to ..

```
STEP-BUILD

+ buildah --storage-driver=vfs bud --format=oci --tls-verify=true --no-cache -f docker/Dockerfile -t docker.io/sbose78/foobar:dev-java-springboot-basic:fc8bfef4a62a54ef5a6c9e0e083f191df0e78148 /workspace/source
STEP 1: FROM maven:3.8.1-openjdk-17-slim
Resolving "maven" using unqualified-search registries (/etc/containers/registries.conf)
STEP 2: FROM openjdk:11-jdk
error creating build container: 3 errors occurred while pulling:
 * Error initializing source docker://registry.access.redhat.com/maven:3.8.1-openjdk-17-slim: Error reading manifest 3.8.1-openjdk-17-slim in registry.access.redhat.com/maven: name unknown: Repo not found
 * Error initializing source docker://registry.redhat.io/maven:3.8.1-openjdk-17-slim: unable to retrieve auth token: invalid username/password: unauthorized: Please login to the Red Hat Registry using your Customer Portal credentials. Further instructions can be found here: https://access.redhat.com/RegistryAuthentication
 * Error initializing source docker://maven:3.8.1-openjdk-17-slim: unable to retrieve auth token: invalid username/password: unauthorized: incorrect username or password
Resolving "openjdk" using unqualified-search registries (/etc/containers/registries.conf)
level=error msg="exit status 125"
```