### PR TITLE
reference parent stack

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -11,11 +11,9 @@ metadata:
   language: "java"
   provider: Red Hat
   supportUrl: https://github.com/devfile-samples/devfile-support#support-information
-starterProjects:
-  - name: springbootproject
-    git:
-      remotes:
-        origin: "https://github.com/odo-devfiles/springboot-ex.git"
+parent:
+  id: java-springboot
+  registryUrl: "https://registry.devfile.io"
 components:
   - name: outerloop-build
     image:
@@ -27,42 +25,7 @@ components:
   - name: outerloop-deploy
     kubernetes:
       uri: outerloop-deploy.yaml
-  - name: tools
-    container:
-      image: quay.io/eclipse/che-java11-maven:7.36.0
-      memoryLimit: 768Mi
-      mountSources: true
-      endpoints:
-      - name: '8080-tcp'
-        targetPort: 8080
-      volumeMounts:
-        - name: m2
-          path: /home/user/.m2
-  - name: m2
-    volume:
-      size: 3Gi
 commands:
-  - id: build
-    exec:
-      component: tools
-      commandLine: "mvn clean -Dmaven.repo.local=/home/user/.m2/repository package -Dmaven.test.skip=true"
-      group:
-        kind: build
-        isDefault: true
-  - id: run
-    exec:
-      component: tools
-      commandLine: "mvn -Dmaven.repo.local=/home/user/.m2/repository spring-boot:run"
-      group:
-        kind: run
-        isDefault: true
-  - id: debug
-    exec:
-      component: tools
-      commandLine: "java -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=${DEBUG_PORT},suspend=n -jar target/*.jar"
-      group:
-        kind: debug
-        isDefault: true
   - id: build-image
     apply:
       component: outerloop-build


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

For issue: https://github.com/devfile/api/issues/715
For the samples, we want to suggest an actual usage, we should reference parent stack instead of copy the parent devfile content inside the main devfile. 