### PR TITLE
Update Dockerfile image to quay to avoid Docker's pull rate limit

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@
 #
 # docker run -i --rm -p 8081:8081 springboot/sample-demo
 ####
-FROM maven:3.8.1-openjdk-17-slim
+FROM quay.io/mfaisal2/maven:3.8.1-openjdk-17-slim
 
 WORKDIR /build
 


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>

This PR updates the Dockerfile base image to quay registry to avoid dockerhub's rate pull limit

The new image is basically a one line wrapper, that is pushed to quay https://quay.io/repository/mfaisal2/maven
```
FROM maven:3.8.1-openjdk-17-slim
```

<img width="928" alt="Screen Shot 2022-05-02 at 2 19 34 PM" src="https://user-images.githubusercontent.com/31771087/166303405-c837cda6-68f2-4498-b974-1fec5b4acef0.png">
<img width="903" alt="Screen Shot 2022-05-02 at 2 19 45 PM" src="https://user-images.githubusercontent.com/31771087/166303407-762a4022-31b2-4e83-a30a-a41bd03cb2d0.png">
