### PR TITLE
Compute the name of the built jar in the Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,10 +18,15 @@ COPY pom.xml .
 RUN mvn dependency:go-offline
 
 COPY src src
-RUN mvn package -Dmaven.test.skip=true
+RUN mvn package -Dmaven.test.skip=true 
+# compute the created jar name and put it in a known location to copy to the next layer.
+# If the user changes pom.xml to have a different version, or artifactId, this will find the jar 
+RUN grep version /build/target/maven-archiver/pom.properties | cut -d '=' -f2 >.env-version 
+RUN grep artifactId /build/target/maven-archiver/pom.properties | cut -d '=' -f2 >.env-id
+RUN mv /build/target/$(cat .env-id)-$(cat .env-version).jar /build/target/export-run-artifact.jar
 
 FROM openjdk:11-jdk
-COPY --from=0 /build/target/demo-0.0.1-SNAPSHOT.jar /app/target/demo-0.0.1-SNAPSHOT.jar
+COPY --from=0 /build/target/export-run-artifact.jar  /app/target/export-run-artifact.jar
 
 EXPOSE 8081
-ENTRYPOINT [ "java", "-jar", "/app/target/demo-0.0.1-SNAPSHOT.jar", "--server.port=8081" ]
+ENTRYPOINT [ "java", "-jar", "/app/target/export-run-artifact.jar", "--server.port=8081" ]


### PR DESCRIPTION
This pull request updates the Dockerfile to use the artifactId, and version output by maven to determine the name of the built jar.

The issue is that if the user changes the version or artifactId in the pom, the old Dockerfile hardcoded these names as `demo` and `0.0.1-SNAPSHOT`.  If these are changed in the pom.xml, the docker build would fail in attempting to copy the jar as the name would be incorrect. 

This change copies the built file to a known location and copies that to the /app directory in the run layer. 
