### PR TITLE
revert back the change to the tag

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -9,7 +9,7 @@ metadata:
   icon: https://spring.io/images/projects/spring-edf462fec682b9d48cf628eaf9e19521.svg
   tags:
     - Java
-    - Spring Boot
+    - Spring
   projectType: springboot
   language: Java
   provider: Red Hat


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

This PR revert back the tag change to Spring boot stacks & samples.
Alizer expect the tag to be Spring to match for devfile.

To fix issue https://issues.redhat.com/browse/DEVHAS-219