### PR TITLE
Update port from 8081 to 8080

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Creating an application with a Spring Boot code sample
 
-**Note:** The Spring Boot code sample uses the **8081** HTTP port.
+**Note:** The Spring Boot code sample uses the **8080** HTTP port.
 
 Before you begin creating an application with this `devfile` code sample, it's helpful to understand the relationship between the `devfile` and `Dockerfile` and how they contribute to your build. You can find these files at the following URLs:
 

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -17,7 +17,7 @@ spec:
           image: java-springboot-image:latest
           ports:
             - name: http
-              containerPort: 8081
+              containerPort: 8080
               protocol: TCP
           resources:
             requests:
@@ -30,9 +30,9 @@ metadata:
   name: my-java-springboot-svc
 spec:
   ports:
-    - name: http-8081
-      port: 8081
+    - name: http-8080
+      port: 8080
       protocol: TCP
-      targetPort: 8081
+      targetPort: 8080
   selector:
     app: java-springboot-app

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -30,12 +30,12 @@ components:
       deployment/replicas: 1
       deployment/cpuRequest: 10m
       deployment/memoryRequest: 180Mi
-      deployment/container-port: 8081
+      deployment/container-port: 8080
     kubernetes:
       uri: deploy.yaml
       endpoints:
-        - name: http-8081
-          targetPort: 8081
+        - name: http-8080
+          targetPort: 8080
           path: /
 commands:
   - id: build-image


### PR DESCRIPTION
- Updates the devfile sample port from 8081 to 8080
- Doesnt update the attribute alpha.dockerimage-port: 8081 because of backward compatibility in ODC earlier versions. We dont want to backport devfile/library update that far back.