### PR TITLE
Pin the parent Devfile version to 1.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .project
 .settings
 target
-.odo/env
+.odo
 .idea
 .DS_Store
+

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -17,6 +17,7 @@ metadata:
 parent:
   id: java-springboot
   registryUrl: 'https://registry.devfile.io'
+  version: 1.2.0
 components:
   - name: image-build
     image:


### PR DESCRIPTION
The default version of the parent Stack will be updated in [1] to use JDK 17,
so that users on recent versions of Spring Boot can use such Stack.

This PR is to make sure this sample does not break with such a change,
and continues to work as before, since it is still using Sprint Boot 2.x.

[1] https://github.com/devfile/registry/pull/169
