### PR TITLE
Enable TLS for version 1

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -38,6 +38,7 @@ components:
         - name: http-8081
           targetPort: 8081
           path: /
+          secure: true
 commands:
   - id: build-image
     apply:


### PR DESCRIPTION
# Description

Set `secure` to `true` to prompt devtools, such as ODC, to create a route with tls enabled.

This should enable TLS on OpenShift for this sample when web console has been patched: https://github.com/devfile/api/issues/1270#issuecomment-1866424653

fixes part of devfile/api#1270